### PR TITLE
Change the default url again

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'ca-alert-prototype.s3.amazonaws.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: 'ca-alert.herokuapp.com', protocol: 'https' }
   config.action_mailer.smtp_settings = {
     address: 'smtp.sendgrid.net',
     port: '587',


### PR DESCRIPTION
This is a little bit weird... for the verification email we want the link in the mail to hit an endpoint on the API, which will verify the user and then redirect over to the React app. For all other emails, the links will need to be to the React app. But we don't have great control of how Devise formulates its urls, so I'm going to default the value to the API root and then in other mailers we write I'll have to set the url options for that mailer to the React app's root.