### PR TITLE
Change the default confirm success URL

### DIFF
--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -1,7 +1,7 @@
 DeviseTokenAuth.setup do |config|
   url_options = Rails.application.config.action_mailer.default_url_options
   if Rails.env.production?
-    config.default_confirm_success_url = "#{url_options[:protocol]}://#{url_options[:host]}"
+    config.default_confirm_success_url = 'https://ca-alert-prototype.s3.amazonaws.com/index.html'
   else
     config.default_confirm_success_url = "http://#{url_options[:host]}:#{url_options[:port]}"
   end


### PR DESCRIPTION
This changes the confirm success URL again in response to my previous change to the default url options. The confirmation URL should point at the React app, but when I changed the default URL options the code was leading it to point at the API. This now hard-codes it to point at the React app.