### PR TITLE
Allow updates to email_notifications_enabled

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::API
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   def require_admin
     if !current_user&.has_role?(:admin)
       render(
@@ -25,5 +27,9 @@ class ApplicationController < ActionController::API
       },
       status: 404
     )
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:account_update, keys: [:email_notifications_enabled])
   end
 end

--- a/backend/lib/devise_swagger_blocks.rb
+++ b/backend/lib/devise_swagger_blocks.rb
@@ -60,7 +60,7 @@ class DeviseSwaggerBlocks
       key :tags, ['auth']
       parameter do
         key :name, :password
-        key :in, :query
+        key :in, :body
         key :description, 'New password for the user'
         key :required, false
         schema do
@@ -70,12 +70,21 @@ class DeviseSwaggerBlocks
       end
       parameter do
         key :name, :password_confirmation
-        key :in, :query
+        key :in, :body
         key :description, 'New password for the user again, must match password parameter'
         key :required, false
         schema do
           key :type, :string
           key :format, :password
+        end
+      end
+      parameter do
+        key :name, :email_notifications_enabled
+        key :in, :body
+        key :description, 'Should email notifications be sent to the user'
+        key :required, false
+        schema do
+          key :type, :boolean
         end
       end
       parameter do

--- a/backend/spec/features/authentication_spec.rb
+++ b/backend/spec/features/authentication_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe 'authentication', type: :request do
             expect(response).to be_success
           end
 
+          it 'lets me update email_notifications_enabled' do
+            user = User.first
+            expect(user.reload.email_notifications_enabled).to be true
+            put(
+              '/auth',
+              headers: {
+                uid: email,
+                client: response.headers['client'],
+                'access-token' => response.headers['access-token']
+              },
+              params: {
+                email_notifications_enabled: false
+              }
+            )
+            expect(response).to be_success
+            expect(user.reload.email_notifications_enabled).to be false
+          end
+
           it 'can delete the user' do
             delete '/auth', headers: {
               uid: email,


### PR DESCRIPTION
This tweaks the PUT action on /auth to make it allow updates to email_notifications_enabled.

@gcs272 we're using devise (a Ruby gem) for user management and it has its own ideas about the endpoints to use for updating users, so that's why this isn't a PATCH on /users/{id} or something more standard with the rest of the API. Also, I called the field email_notifications_enabled because it's on the user rather than on a specific email address, and I thought calling it notifications_enabled would imply that it turned off all notifications for the user.

So you'll want to make a PUT to the /auth endpoint passing email_notifications_enabled=false in the body.