### PR TITLE
Store the current user count in hazards

### DIFF
--- a/backend/app/models/hazard.rb
+++ b/backend/app/models/hazard.rb
@@ -9,6 +9,7 @@ class Hazard < ApplicationRecord
   validates :message, presence: true
   validates :radius_in_meters, presence: true
 
+  after_create :store_current_user_count
   after_create :create_alerts
 
   def as_json(options = {})
@@ -66,6 +67,9 @@ class Hazard < ApplicationRecord
     property :sms_notification_count do
       key :type, :integer
     end
+    property :user_count_at_creation do
+      key :type, :integer
+    end
     property :created_at do
       key :type, :string
       key :format, 'date-time'
@@ -77,6 +81,12 @@ class Hazard < ApplicationRecord
   end
 
   private
+
+  def store_current_user_count
+    # Not using User.count because for seeding the database there may technically be users
+    # created in the future from when the hazard was created.
+    update_attribute(:user_count_at_creation, User.where('created_at < ?', created_at).count)
+  end
 
   def create_alerts
     Place.within_radius_of(coord.lon, coord.lat, radius_in_meters).each do |place|

--- a/backend/config/initializers/twilio.rb
+++ b/backend/config/initializers/twilio.rb
@@ -1,4 +1,4 @@
-if ENV['TWILIO_ACCOUNT_SID'].present? && ENV['TWILIO_AUTH_TOKEN'].present?
+if !Rails.env.test? && ENV['TWILIO_ACCOUNT_SID'].present? && ENV['TWILIO_AUTH_TOKEN'].present?
   Twilio.configure do |config|
     config.account_sid = ENV['TWILIO_ACCOUNT_SID']
     config.auth_token = ENV['TWILIO_AUTH_TOKEN']

--- a/backend/db/migrate/20170301035507_add_current_user_count_to_hazards.rb
+++ b/backend/db/migrate/20170301035507_add_current_user_count_to_hazards.rb
@@ -1,0 +1,5 @@
+class AddCurrentUserCountToHazards < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hazards, :user_count_at_creation, :integer, default: 0
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170227152312) do
+ActiveRecord::Schema.define(version: 20170301035507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,11 +99,12 @@ ActiveRecord::Schema.define(version: 20170227152312) do
     t.string    "link"
     t.string    "phone_number"
     t.integer   "creator_id"
-    t.geography "coord",            limit: {:srid=>4326, :type=>"point", :geographic=>true}
+    t.geography "coord",                  limit: {:srid=>4326, :type=>"point", :geographic=>true}
     t.datetime  "created_at"
     t.datetime  "updated_at"
     t.string    "category"
     t.string    "link_title"
+    t.integer   "user_count_at_creation",                                                          default: 0
     t.index ["creator_id"], name: "index_hazards_on_creator_id", using: :btree
   end
 

--- a/backend/spec/controllers/admin/hazards_controller_spec.rb
+++ b/backend/spec/controllers/admin/hazards_controller_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe Admin::HazardsController, type: :request do
           expect(clowns['email_notifications_sent']).to eq(0)
           expect(clowns['sms_notifications_sent']).to eq(0)
         end
+
+        it 'includes the number of users at creation' do
+          json = JSON.parse(response.body)
+          clowns = json['data'].find { |i| i['id'] == killer_clowns.id }
+          expect(clowns['user_count_at_creation']).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
This is in the `user_count_at_creation` field in hazard JSON objects. Closes #128 