### PR TITLE
Add .vendor_urls file for new buildpack

### DIFF
--- a/backend/.vendor_urls
+++ b/backend/.vendor_urls
@@ -1,0 +1,2 @@
+https://s3.amazonaws.com/diowa-buildpacks/geos-3.6.1-heroku.tar.gz
+https://s3.amazonaws.com/diowa-buildpacks/proj-4.9.3-heroku.tar.gz


### PR DESCRIPTION
Following these instructions http://www.diowa.com/blog/heroku/2016/02/26/using-rgeo-with-geos-on-heroku